### PR TITLE
Changing the way the tasks are registered

### DIFF
--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -70,8 +70,8 @@ module.exports = function(grunt) {
     // Default task.
     grunt.registerTask('default', ['test:sauce:' + _(desireds).keys().first()]);
 
-    _(desireds).each(function(desired, key) {
-            grunt.registerTask('test:sauce:' + key, ['env:' + key, 'simplemocha:sauce']);
+    _.each(desireds, function(desired, key) {
+      grunt.registerTask('test:sauce:' + key, ['env:' + key, 'simplemocha:sauce']);
     });
 
     grunt.registerTask('test:sauce:parallel', ['concurrent:test-sauce']);


### PR DESCRIPTION
This will make the following error go away.

➜  tutorial git:(JO-Wednesday2) ✗ grunt
Warning: Task "test:sauce:chrome" not found. Use --force to continue.

Aborted due to warnings.

This is found in the tutorial project and I think it is because lodash does not accept that old format for an _.each