### PR TITLE
changed _.each to _.forIn to support latest lodash method

### DIFF
--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -45,8 +45,8 @@ var gruntConfig = {
             },
         },
     };
- 
-_(desireds).each(function(desired, key) {
+
+_.forIn(desireds,function(desired, key) {
     gruntConfig.env[key] = { 
         DESIRED: JSON.stringify(desired)
     };
@@ -70,7 +70,7 @@ module.exports = function(grunt) {
     // Default task.
     grunt.registerTask('default', ['test:sauce:' + _(desireds).keys().first()]);
 
-    _(desireds).each(function(desired, key) {
+    _.forIn(desireds,function(desired, key) {
             grunt.registerTask('test:sauce:' + key, ['env:' + key, 'simplemocha:sauce']);
     });
 

--- a/template.js
+++ b/template.js
@@ -54,8 +54,8 @@ exports.template = function(grunt, init, done) {
             'wd': 'latest',
             'chai': 'latest',
             'chai-as-promised': 'latest',
-            'lodash': '~2.4.1',
-            'colors': 'latest',
+            'lodash': 'latest',
+            'colors': 'latest'
         };
 
         // Files to copy (and process).


### PR DESCRIPTION
Since the new *lodash* abandoned the former ```_.each``` method for objects, I think it's a nice idea to keep with the latest release to downgrade it. I saw that @grommett went the easier way and went backwards but this is not very efficient. *Lodash* is now on 3.5.0 and it makes more sense to keep it up.

What do you guys think?