### PR TITLE
increase timeout to work with all platform

### DIFF
--- a/root/Gruntfile.js
+++ b/root/Gruntfile.js
@@ -11,7 +11,7 @@ var gruntConfig = {
         simplemocha: {
             sauce: {
                 options: {
-                    timeout: 60000,
+                    timeout: 300000,
                     reporter: 'spec'
                 },
                 src: ['test/sauce/**/*-specs.js']


### PR DESCRIPTION
In some platform (for eg. ios) vm wont start in 60 seconds.